### PR TITLE
Add more context data to the rate limit handler

### DIFF
--- a/README.org
+++ b/README.org
@@ -43,7 +43,7 @@ If you want to do some specific operations when a call is rate limited, you can 
                                :rate-limit-handler 
                                 (fn [request next-slot-in-sec limit]
                                  {:status 429
-                                  :body (format "Too many requests, try later in %d ms"
+                                  :body (format "Too many requests, try later in %d s"
                                                 next-slot-in-sec)})}))
 #+END_SRC
 

--- a/README.org
+++ b/README.org
@@ -41,10 +41,10 @@ If you want to do some specific operations when a call is rate limited, you can 
                                :key-prefix "your-api"
                                :limit-fns [(ip-limit 200)]
                                :rate-limit-handler 
-                                (fn [request next-slot-in-ms]
+                                (fn [request next-slot-in-sec limit]
                                  {:status 429
                                   :body (format "Too many requests, try later in %d ms"
-                                                next-slot-in-ms)})}))
+                                                next-slot-in-sec)})}))
 #+END_SRC
 
 *** Custom limit

--- a/src/ring/middleware/turnstile.clj
+++ b/src/ring/middleware/turnstile.clj
@@ -92,9 +92,9 @@
   [{:keys [turnstile nb-request-per-hour name-in-headers]} :- Limit]
   (let [remaining (space turnstile nb-request-per-hour)]
     (hash-map (format "X-RateLimit-%s-Limit" name-in-headers)
-              nb-request-per-hour
+              (str nb-request-per-hour)
               (format "X-RateLimit-%s-Remaining" name-in-headers)
-              remaining)))
+              (str remaining))))
 
 (s/defn compute-limits :- [Limit]
   [limit-fns :- [LimitFunction]

--- a/src/ring/middleware/turnstile.clj
+++ b/src/ring/middleware/turnstile.clj
@@ -85,7 +85,7 @@
   [request next-slot-in-sec limit]
   {:status 429
    :headers {"Content-Type" "application/json"
-             "Retry-After" next-slot-in-sec}
+             "Retry-After" (str next-slot-in-sec)}
    :body "{\"error\": \"Too Many Requests\"}"})
 
 (s/defn rate-limit-headers

--- a/test/ring/middleware/turnstile_test.clj
+++ b/test/ring/middleware/turnstile_test.clj
@@ -23,7 +23,7 @@
 (deftest default-rate-limit-handler-test
   (is (= {:status 429
           :headers {"Content-Type" "application/json"
-                    "Retry-After" 3}
+                    "Retry-After" "3"}
           :body "{\"error\": \"Too Many Requests\"}"}
          (sut/default-rate-limit-handler {} 3 {}))))
 
@@ -58,7 +58,7 @@
                   (sut/wrap-rate-limit {:redis-conf {}
                                         :limit-fns [(sut/ip-limit 5)]
                                         :rate-limit-handler
-                                        (fn [request next-slot-in-ms _]
+                                        (fn [request next-slot-in-sec _]
                                           {:status 429
                                            :headers {"Content-Type" "application/text"}
                                            :body "Too many requests, retry later"})}))]

--- a/test/ring/middleware/turnstile_test.clj
+++ b/test/ring/middleware/turnstile_test.clj
@@ -48,7 +48,7 @@
         (dotimes [_ 5] (-> (request :get "/") app))
         (let [response (-> (request :get "/") app)]
           (is (= 429 (:status response)))
-          (is (= 3600 (get-in response [:headers "Retry-After"])))
+          (is (= "3600" (get-in response [:headers "Retry-After"])))
           (is (= "{\"error\": \"Too Many Requests\"}"
                  (:body response)))))))
   (testing "Custom rate limit handler"

--- a/test/ring/middleware/turnstile_test.clj
+++ b/test/ring/middleware/turnstile_test.clj
@@ -25,7 +25,7 @@
           :headers {"Content-Type" "application/json"
                     "Retry-After" 3}
           :body "{\"error\": \"Too Many Requests\"}"}
-         (sut/default-rate-limit-handler {} 2500))))
+         (sut/default-rate-limit-handler {} 3 {}))))
 
 (defn wrap-with-exception
   [f]
@@ -58,7 +58,7 @@
                   (sut/wrap-rate-limit {:redis-conf {}
                                         :limit-fns [(sut/ip-limit 5)]
                                         :rate-limit-handler
-                                        (fn [request next-slot-in-ms]
+                                        (fn [request next-slot-in-ms _]
                                           {:status 429
                                            :headers {"Content-Type" "application/text"}
                                            :body "Too many requests, retry later"})}))]

--- a/test/ring/middleware/turnstile_test.clj
+++ b/test/ring/middleware/turnstile_test.clj
@@ -42,8 +42,8 @@
                                         :limit-fns [(sut/ip-limit 5)]}))]
       (testing "Rate limit headers"
         (let [response (-> (request :get "/") app)]
-          (is (= 4 (get-in response [:headers "X-RateLimit-IP-Remaining"])))
-          (is (= 5 (get-in response [:headers "X-RateLimit-IP-Limit"])))))
+          (is (= "4" (get-in response [:headers "X-RateLimit-IP-Remaining"])))
+          (is (= "5" (get-in response [:headers "X-RateLimit-IP-Limit"])))))
       (testing "Rate limit status and response"
         (dotimes [_ 5] (-> (request :get "/") app))
         (let [response (-> (request :get "/") app)]
@@ -78,30 +78,30 @@
                                                  ip-limit]}))]
       (testing "Limits when the `x-id` header is set"
         (let [response (-> (request :get "/") (header "x-id" "1") app)]
-          (is (= 9 (get-in response [:headers "X-RateLimit-ID-Remaining"])))
-          (is (= 10 (get-in response [:headers "X-RateLimit-ID-Limit"]))))
+          (is (= "9" (get-in response [:headers "X-RateLimit-ID-Remaining"])))
+          (is (= "10" (get-in response [:headers "X-RateLimit-ID-Limit"]))))
         (let [response (-> (request :get "/") (header "x-id" "2")app)]
-          (is (= 9 (get-in response [:headers "X-RateLimit-ID-Remaining"])))
-          (is (= 10 (get-in response [:headers "X-RateLimit-ID-Limit"])))
-          (is (= 6 (get-in response [:headers "X-RateLimit-IP-Remaining"])))
-          (is (= 8 (get-in response [:headers "X-RateLimit-IP-Limit"])))))
+          (is (= "9" (get-in response [:headers "X-RateLimit-ID-Remaining"])))
+          (is (= "10" (get-in response [:headers "X-RateLimit-ID-Limit"])))
+          (is (= "6" (get-in response [:headers "X-RateLimit-IP-Remaining"])))
+          (is (= "8" (get-in response [:headers "X-RateLimit-IP-Limit"])))))
       (testing "Limits when the `x-id` header is not set"
         (let [response (-> (request :get "/") app)]
-          (is (= 5 (get-in response [:headers "X-RateLimit-IP-Remaining"])))
-          (is (= 8 (get-in response [:headers "X-RateLimit-IP-Limit"]))))
+          (is (= "5" (get-in response [:headers "X-RateLimit-IP-Remaining"])))
+          (is (= "8" (get-in response [:headers "X-RateLimit-IP-Limit"]))))
         (let [response (-> (request :get "/") (header "x-id" "1") app)]
-          (is (= 8 (get-in response [:headers "X-RateLimit-ID-Remaining"])))
-          (is (= 10 (get-in response [:headers "X-RateLimit-ID-Limit"]))))
+          (is (= "8" (get-in response [:headers "X-RateLimit-ID-Remaining"])))
+          (is (= "10" (get-in response [:headers "X-RateLimit-ID-Limit"]))))
         (let [response (-> (request :get "/") (header "x-id" "2") app)]
-          (is (= 8 (get-in response [:headers "X-RateLimit-ID-Remaining"])))
-          (is (= 10 (get-in response [:headers "X-RateLimit-ID-Limit"])))))
+          (is (= "8" (get-in response [:headers "X-RateLimit-ID-Remaining"])))
+          (is (= "10" (get-in response [:headers "X-RateLimit-ID-Limit"])))))
       (testing "Unlimited limit for the exception limit"
         (let [response (-> (request :get "/") (header "x-id" "1234") app)]
           (is (not (contains? (:headers response) "X-RateLimit-ID-Remaining")))
           (is (not (contains? (:headers response) "X-RateLimit-IP-Remaining"))))
         (let [response (-> (request :get "/") (header "x-id" "1") app)]
-          (is (= 7 (get-in response [:headers "X-RateLimit-ID-Remaining"])))
-          (is (= 10 (get-in response [:headers "X-RateLimit-ID-Limit"]))))))))
+          (is (= "7" (get-in response [:headers "X-RateLimit-ID-Remaining"])))
+          (is (= "10" (get-in response [:headers "X-RateLimit-ID-Limit"]))))))))
 
 (deftest wrap-rate-limit-key-prefix-test
   (let [app1 (-> (fn [req] {:status 200
@@ -117,6 +117,6 @@
                                        :key-prefix "api-2"
                                        :limit-fns [(sut/ip-limit 5)]}))]
     (let [response (-> (request :get "/") app1)]
-      (is (= 4 (get-in response [:headers "X-RateLimit-IP-Remaining"]))))
+      (is (= "4" (get-in response [:headers "X-RateLimit-IP-Remaining"]))))
     (let [response (-> (request :get "/") app2)]
-      (is (= 4 (get-in response [:headers "X-RateLimit-IP-Remaining"]))))))
+      (is (= "4" (get-in response [:headers "X-RateLimit-IP-Remaining"]))))))


### PR DESCRIPTION
This PR adds the reached limit to the args of the rate limit handler. It contains the following information:

- Rate limit key
- Number of request per hour
- Name of the limit used in headers