### PR TITLE
Fix how the redis connection is defined

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,10 +8,9 @@
                         ["snapshots" {:url "https://clojars.org/repo" :creds :gpg}]]
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/tools.logging "0.4.1"]
-                 [threatgrid/turnstile "0.101"]
+                 [threatgrid/turnstile "0.102-SNAPSHOT"]
                  [metosin/schema-tools "0.10.4"]
                  [prismatic/schema "1.1.9"]
                  [ring/ring-mock "0.3.2"]
                  [ch.qos.logback/logback-classic "1.2.3"]]
   :profile {:dev {:dependencies [[com.taoensso/carmine "2.18.1"]]}})
-

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
                         ["snapshots" {:url "https://clojars.org/repo" :creds :gpg}]]
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/tools.logging "0.4.1"]
-                 [threatgrid/turnstile "0.102-SNAPSHOT"]
+                 [threatgrid/turnstile "0.102"]
                  [metosin/schema-tools "0.10.4"]
                  [prismatic/schema "1.1.9"]
                  [ring/ring-mock "0.3.2"]

--- a/src/ring/middleware/turnstile.clj
+++ b/src/ring/middleware/turnstile.clj
@@ -19,7 +19,7 @@
 (s/defschema LimitFunction
   (s/=> Limit HttpRequest))
 
-(s/defschema RedisConf
+(s/defschema RedisSpec
   (st/optional-keys
    {:host s/Str
     :port s/Int
@@ -27,9 +27,13 @@
     :password s/Str
     :db s/Int}))
 
+(s/defschema RedisConn
+  {:spec RedisSpec
+   :pool s/Any})
+
 (s/defschema Conf
   (st/merge
-   {:redis-conf RedisConf
+   {:redis-conn RedisConn
     :limit-fns [LimitFunction]}
    (st/optional-keys
     {:key-prefix s/Str
@@ -65,11 +69,11 @@
 
 (s/defn with-turnstile :- Limit
   [{:keys [rate-limit-key] :as limit} :- Limit
-   {:keys [redis-conf key-prefix] :as ctx}]
+   {:keys [redis-conn key-prefix] :as ctx}]
   (assoc limit
          :turnstile
-         (map->RedisTurnstile {:conn-spec redis-conf
-                               :pool {}
+         (map->RedisTurnstile {:conn-spec (:spec redis-conn)
+                               :pool (:pool redis-conn)
                                :name (cond->> rate-limit-key
                                        key-prefix (str key-prefix "-"))
                                :expiration-ms turnstile-expiration-ms})))
@@ -113,13 +117,13 @@
 (defn wrap-rate-limit
   "Middleware for the turnstile rate limiting service"
   [handler
-   {:keys [redis-conf limit-fns rate-limit-handler key-prefix]
+   {:keys [redis-conn limit-fns rate-limit-handler key-prefix]
     :or {rate-limit-handler default-rate-limit-handler
          key-prefix ""} :as conf}]
   ;; Check the configuration
   (s/validate Conf conf)
   (fn [request]
-    (let [limits (compute-limits limit-fns request {:redis-conf redis-conf
+    (let [limits (compute-limits limit-fns request {:redis-conn redis-conn
                                                     :key-prefix key-prefix})
           reached-limit (first-reached-limit limits)]
       (if reached-limit

--- a/src/ring/middleware/turnstile.clj
+++ b/src/ring/middleware/turnstile.clj
@@ -28,8 +28,9 @@
     :db s/Int}))
 
 (s/defschema RedisConn
-  {:spec RedisSpec
-   :pool s/Any})
+  (st/optional-keys
+   {:spec RedisSpec
+    :pool s/Any}))
 
 (s/defschema Conf
   (st/merge

--- a/test/ring/middleware/turnstile_test.clj
+++ b/test/ring/middleware/turnstile_test.clj
@@ -38,7 +38,7 @@
     (let [app (-> (fn [req] {:status 200
                              :headers {"Content-Type" "application/json"}
                              :body "{}"})
-                  (sut/wrap-rate-limit {:redis-conf {}
+                  (sut/wrap-rate-limit {:redis-conn {}
                                         :limit-fns [(sut/ip-limit 5)]}))]
       (testing "Rate limit headers"
         (let [response (-> (request :get "/") app)]
@@ -55,7 +55,7 @@
     (let [app (-> (fn [req] {:status 200
                              :headers {"Content-Type" "application/json"}
                              :body "{}"})
-                  (sut/wrap-rate-limit {:redis-conf {}
+                  (sut/wrap-rate-limit {:redis-conn {}
                                         :limit-fns [(sut/ip-limit 5)]
                                         :rate-limit-handler
                                         (fn [request next-slot-in-sec _]
@@ -73,7 +73,7 @@
           app (-> (fn [req] {:status 200
                              :headers {"Content-Type" "application/json"}
                              :body "{}"})
-                  (sut/wrap-rate-limit {:redis-conf {}
+                  (sut/wrap-rate-limit {:redis-conn {}
                                         :limit-fns [header-limit
                                                  ip-limit]}))]
       (testing "Limits when the `x-id` header is set"
@@ -107,13 +107,13 @@
   (let [app1 (-> (fn [req] {:status 200
                            :headers {"Content-Type" "application/json"}
                            :body "{}"})
-                (sut/wrap-rate-limit {:redis-conf {}
+                (sut/wrap-rate-limit {:redis-conn {}
                                       :key-prefix "api-1"
                                       :limit-fns [(sut/ip-limit 5)]}))
         app2 (-> (fn [req] {:status 200
                             :headers {"Content-Type" "application/json"}
                             :body "{}"})
-                 (sut/wrap-rate-limit {:redis-conf {}
+                 (sut/wrap-rate-limit {:redis-conn {}
                                        :key-prefix "api-2"
                                        :limit-fns [(sut/ip-limit 5)]}))]
     (let [response (-> (request :get "/") app1)]


### PR DESCRIPTION
This PR updates turnstile to the latest version and now a pool can be specified for the redis connection.