### PR TITLE
Fix redis conn issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: clojure
 script: lein test
-services:
-  - redis-server
+before_script: sudo redis-server /etc/redis/redis.conf --port 6380

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
                         ["snapshots" {:url "https://clojars.org/repo" :creds :gpg}]]
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/tools.logging "0.4.1"]
-                 [threatgrid/turnstile "0.102"]
+                 [threatgrid/turnstile "0.103-SNAPSHOT"]
                  [metosin/schema-tools "0.10.4"]
                  [prismatic/schema "1.1.9"]
                  [ring/ring-mock "0.3.2"]

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
                         ["snapshots" {:url "https://clojars.org/repo" :creds :gpg}]]
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/tools.logging "0.4.1"]
-                 [threatgrid/turnstile "0.103-SNAPSHOT"]
+                 [threatgrid/turnstile "0.103"]
                  [metosin/schema-tools "0.10.4"]
                  [prismatic/schema "1.1.9"]
                  [ring/ring-mock "0.3.2"]


### PR DESCRIPTION
Depends on threatgrid/turnstile#2

- Use the latest version of `turnstile`
- Use a non default redis port for all integration tests