### PR TITLE
Add all suported options to the RedisSpec schema

### DIFF
--- a/src/ring/middleware/turnstile.clj
+++ b/src/ring/middleware/turnstile.clj
@@ -25,6 +25,8 @@
     :port s/Int
     :uri s/Str
     :password s/Str
+    :ssl-fn s/Any
+    :timeout-ms s/Int
     :db s/Int}))
 
 (s/defschema RedisConn


### PR DESCRIPTION
Some supported options were missing from the `RedisSpec` schema. This PR add them.